### PR TITLE
Process_ca.service

### DIFF
--- a/Process_ca.service
+++ b/Process_ca.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Will launch the bash script that imports CA data into database
+
+
+[Service]
+Type=idle
+ExecStart=/home/pi/CAScripts/process.ca.sh
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This file must be added to /lib/systemd/system/ and enabled through systemctl for Jessie systems.

I found, on jessie, that the best way to launch on startup is to create a service. The above will directly launch the process.ca.sh script.
This should also replace the Launch script in jessie vs Wheezy.