### PR TITLE
python_serial.service

### DIFF
--- a/python_serial.service
+++ b/python_serial.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Launches a script that will pull CA data
+After=multi-user.target
+
+[Service]
+Type=idle
+ExecStart=/usr/bin/python /home/pi/CAScripts/python_serial.py >/dev/null 2>&1 &
+
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This file must be added to /lib/systemd/system/ and enabled through systemctl for Jessie systems.

I found, on jessie, that the best way to launch on startup is to create a service. The above will directly launch the python_serial.py script.
This should also replace the Launch script in jessie vs Wheezy.